### PR TITLE
Imviz linking radio/switch buttons

### DIFF
--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -20,11 +20,10 @@ class LinksControl(TemplateMixin):
     wcs_use_fallback = Bool(True).tag(sync=True)
     wcs_use_affine = Bool(True).tag(sync=True)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     def vue_do_link(self, *args, **kwargs):
-        """Run :meth:`jdaviz.configs.imviz.helper.Imviz.link_data`
+        """Run :func:`jdaviz.configs.imviz.helper.link_image_data`
+
         with the selected parameters.
         """
         link_image_data(

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -1,4 +1,4 @@
-from traitlets import List
+from traitlets import List, Unicode, Bool
 
 from jdaviz.configs.imviz.helper import link_image_data
 from jdaviz.core.registries import tray_registry
@@ -12,39 +12,24 @@ __all__ = ['LinksControl']
 class LinksControl(TemplateMixin):
     template = load_template("links_control.vue", __file__).tag(sync=True)
 
-    # TODO: Use radio button groups?
     link_types = List(['Pixels', 'WCS']).tag(sync=True)
-    wcs_fallback_schemes = List(['None', 'Pixels']).tag(sync=True)
-    wcs_use_affine_options = List(['Yes', 'No']).tag(sync=True)
+
+    # default states. NOTE: same case as options above, any necessary casting
+    # to internal API formats should be in vue_do_link)
+    link_type = Unicode('Pixels').tag(sync=True)
+    wcs_use_fallback = Bool(True).tag(sync=True)
+    wcs_use_affine = Bool(True).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._link_type = 'pixels'
-        self._wcs_fallback_scheme = None
-        self._wcs_use_affine = True
-
-    def vue_link_type_selected(self, event):
-        if event == 'WCS':
-            self._link_type = 'wcs'
-        else:
-            self._link_type = 'pixels'
-
-    def vue_wcs_fallback_scheme_selected(self, event):
-        if event == 'None':
-            self._wcs_fallback_scheme = None
-        else:
-            self._wcs_fallback_scheme = 'pixels'
-
-    def vue_affine_option_selected(self, event):
-        if event == 'Yes':
-            self._wcs_use_affine = True
-        else:
-            self._wcs_use_affine = False
 
     def vue_do_link(self, *args, **kwargs):
         """Run :meth:`jdaviz.configs.imviz.helper.Imviz.link_data`
         with the selected parameters.
         """
         link_image_data(
-            self.app, link_type=self._link_type, wcs_fallback_scheme=self._wcs_fallback_scheme,
-            wcs_use_affine=self._wcs_use_affine, error_on_fail=False)
+            self.app,
+            link_type=self.link_type.lower(),
+            wcs_fallback_scheme='pixels' if self.wcs_use_fallback else None,
+            wcs_use_affine=self.wcs_use_affine,
+            error_on_fail=False)

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.py
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.py
@@ -20,10 +20,8 @@ class LinksControl(TemplateMixin):
     wcs_use_fallback = Bool(True).tag(sync=True)
     wcs_use_affine = Bool(True).tag(sync=True)
 
-
     def vue_do_link(self, *args, **kwargs):
         """Run :func:`jdaviz.configs.imviz.helper.link_image_data`
-
         with the selected parameters.
         """
         link_image_data(

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -20,7 +20,8 @@
                </v-radio-group>
             </v-col>
           </v-row>
-          <v-row v-if="link_type == 'WCS'">
+          <v-row v-if="false">
+
             <v-col>
               <v-switch
                 label="Fallback on Pixels"

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -5,39 +5,41 @@
         <v-container>
           <v-row>
             <v-col>
-              <v-select
-                :items="link_types"
-                @change="link_type_selected"
+              <v-radio-group 
                 label="Link type"
                 hint="Type of linking to be done."
+                v-model="link_type"
                 persistent-hint
-              ></v-select>
+                row>
+                <v-radio
+                  v-for="item in link_types"
+                  :key="item"
+                  :label="item"
+                  :value="item"
+                ></v-radio>
+               </v-radio-group>
             </v-col>
           </v-row>
-        </v-container>
-        <v-container>
-          <v-row>
+          <v-row v-if="link_type == 'WCS'">
             <v-col>
-              <v-select
-                :items="wcs_fallback_schemes"
-                @change="wcs_fallback_scheme_selected"
-                label="WCS fallback scheme"
-                hint="If WCS linking fails, fall back to linking by pixels or not at all."
+              <v-switch
+                label="Fallback on Pixels"
+                hint="If WCS linking fails, fallback to linking by pixels."
+                v-model="wcs_use_fallback"
                 persistent-hint
-              ></v-select>
+                inset>
+              </v-switch>
             </v-col>
           </v-row>
-        </v-container>
-        <v-container>
-          <v-row>
+          <v-row v-if="link_type == 'WCS'">
             <v-col>
-              <v-select
-                :items="wcs_use_affine_options"
-                @change="affine_option_selected"
-                label="Use affine transform"
+              <v-switch
+                label="Affine transform"
                 hint="Use affine transform for WCS, if possible."
+                v-model="wcs_use_affine"
                 persistent-hint
-              ></v-select>
+                inset>
+              </v-switch>
             </v-col>
           </v-row>
         </v-container>

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -34,8 +34,8 @@
           <v-row v-if="link_type == 'WCS'">
             <v-col>
               <v-switch
-                label="Affine transform"
-                hint="Use affine transform for WCS, if possible."
+                label="Fast approximation"
+                hint="Use fast approximation for image alignment if possible (accurate to <1 pixel)."
                 v-model="wcs_use_affine"
                 persistent-hint
                 inset>

--- a/jdaviz/configs/imviz/plugins/links_control/links_control.vue
+++ b/jdaviz/configs/imviz/plugins/links_control/links_control.vue
@@ -21,7 +21,6 @@
             </v-col>
           </v-row>
           <v-row v-if="false">
-
             <v-col>
               <v-switch
                 label="Fallback on Pixels"
@@ -59,3 +58,12 @@
     </v-card>
   </v-card>
 </template>
+
+<style>
+
+/* addresses https://github.com/pllim/jdaviz/pull/3#issuecomment-926820530 */
+div[role=radiogroup] > legend {
+  width: 100%;
+}
+
+</style>


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request implements radio buttons and switches with default values in place of dropdown boxes for the Imviz linking plugin.  The two switches for WCS are only visible if WCS is selected in the first row (see screenshots).  

<img width="990" alt="Screen Shot 2021-09-24 at 12 45 49 PM" src="https://user-images.githubusercontent.com/877591/134712379-0ac03ea5-556a-4ed1-b621-3c9ade9abaf0.png">

<img width="990" alt="Screen Shot 2021-09-24 at 12 46 02 PM" src="https://user-images.githubusercontent.com/877591/134712388-3b4ce792-54e8-43c0-9cc3-7f987e99a366.png">

By default, "fallback on pixels" is enabled but still visible.  If manually disabled and WCS fails, a yellow snackbar is raised with a (currently) unfriendly message.  @camipacifici - would you rather this option be removed entirely from the UI but left as "fallback on pixels" under-the-hood?  

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Are two approvals required? Branch protection rule does not check for the second approval. If a second approval is not necessary, please apply the `trivial` label.
- [ ] Do the proposed changes actually accomplish desired goals? Also manually run the affected example notebooks, if necessary.
- [ ] Do the proposed changes follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are tests added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Are docs added/updated as required? If so, do they follow the [STScI Style Guides](https://github.com/spacetelescope/style-guides)?
- [ ] Did the CI pass? If not, are the failures related?
- [ ] Is a change log needed? If yes, is it added to `CHANGES.rst`?
- [ ] Is a milestone set? Milestone is only currently required for PRs related to Imviz MVP.
- [ ] After merge, any internal documentations need updating (e.g., JIRA, Innerspace)?
