### PR TITLE
switch from change to observe events

### DIFF
--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.py
@@ -148,23 +148,23 @@ class SimpleAperturePhotometry(TemplateMixin):
         if bg_subset_selected == 'Manual':
             # we'll later access the user's self.background_value directly
             return
-        else:
-            try:
-                # Basically same way image stats are calculated in vue_do_aper_phot()
-                # except here we only care about one stat for the background.
-                data = self._selected_data
-                reg = self._get_region_from_subset(bg_subset_selected)
-                comp = data.get_component(data.main_components[0])
-                aper_mask_stat = reg.to_mask(mode='center')
-                img_stat = aper_mask_stat.get_values(comp.data, mask=None)
 
-                # photutils/background/_utils.py --> nanmedian()
-                self.background_value = np.nanmedian(img_stat)  # Naturally in data unit
+        try:
+            # Basically same way image stats are calculated in vue_do_aper_phot()
+            # except here we only care about one stat for the background.
+            data = self._selected_data
+            reg = self._get_region_from_subset(bg_subset_selected)
+            comp = data.get_component(data.main_components[0])
+            aper_mask_stat = reg.to_mask(mode='center')
+            img_stat = aper_mask_stat.get_values(comp.data, mask=None)
 
-            except Exception as e:
-                self.background_value = 0
-                self.hub.broadcast(SnackbarMessage(
-                    f"Failed to extract {bg_subset_selected}: {repr(e)}", color='error', sender=self))
+            # photutils/background/_utils.py --> nanmedian()
+            self.background_value = np.nanmedian(img_stat)  # Naturally in data unit
+
+        except Exception as e:
+            self.background_value = 0
+            self.hub.broadcast(SnackbarMessage(
+                f"Failed to extract {bg_subset_selected}: {repr(e)}", color='error', sender=self))
 
     def vue_do_aper_phot(self, *args, **kwargs):
         if self._selected_data is None or self._selected_subset is None:

--- a/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
+++ b/jdaviz/configs/imviz/plugins/aper_phot_simple/aper_phot_simple.vue
@@ -9,92 +9,97 @@
     <v-row>
       <v-select
         :items="dc_items"
-        @change="data_selected"
+        v-model="data_selected"
         label="Data"
         hint="Select data for photometry."
         persistent-hint
       ></v-select>
     </v-row>
 
-    <v-row>
-      <v-select
-        :items="subset_items"
-        @change="subset_selected"
-        label="Subset"
-        hint="Select subset region for photometry."
-        persistent-hint
-      ></v-select>
-    </v-row>
+    <div v-if='data_selected'>
+      <v-row>
+        <v-select
+          :items="subset_items"
+          v-model="subset_selected"
+          label="Subset"
+          hint="Select subset region for photometry."
+          persistent-hint
+        ></v-select>
+      </v-row>
 
-    <v-row>
-      <v-select
-        :items="bg_subset_items"
-        @change="bg_subset_selected"
-        label="Subset (background)"
-        hint="Select subset region for background calculation."
-        persistent-hint
-      ></v-select>
-    </v-row>
+      <div v-if="subset_selected">
+        <v-row>
+          <v-select
+            :items="bg_subset_items"
+            v-model="bg_subset_selected"
+            label="Subset (background)"
+            hint="Select subset region for background calculation."
+            persistent-hint
+          ></v-select>
+        </v-row>
 
-    <v-row>
-      <v-text-field
-        label="Background value"
-        v-model="background_value"
-        hint="Background to subtract, same unit as data"
-        persistent-hint
-      >
-      </v-text-field>
-    </v-row>
+        <v-row>
+          <v-text-field
+            label="Background value"
+            v-model="background_value"
+            hint="Background to subtract, same unit as data"
+            :disabled="bg_subset_selected!='Manual'"
+            persistent-hint
+          >
+          </v-text-field>
+        </v-row>
 
-    <v-row>
-      <v-text-field
-        label="Pixel area"
-        v-model="pixel_area"
-        hint="Pixel area in arcsec squared, only used if sr in data unit"
-        persistent-hint
-      >
-      </v-text-field>
-    </v-row>
+        <v-row>
+          <v-text-field
+            label="Pixel area"
+            v-model="pixel_area"
+            hint="Pixel area in arcsec squared, only used if sr in data unit"
+            persistent-hint
+          >
+          </v-text-field>
+        </v-row>
 
-    <v-row>
-      <v-text-field
-        label="Counts conversion factor"
-        v-model="counts_factor"
-        hint="Factor to convert data unit to counts, in unit of flux/counts"
-        persistent-hint
-      >
-      </v-text-field>
-    </v-row>
+        <v-row>
+          <v-text-field
+            label="Counts conversion factor"
+            v-model="counts_factor"
+            hint="Factor to convert data unit to counts, in unit of flux/counts"
+            persistent-hint
+          >
+          </v-text-field>
+        </v-row>
 
-    <v-row>
-      <v-text-field
-        label="Flux scaling"
-        v-model="flux_scaling"
-        hint="Same unit as data, used in -2.5 * log(flux / flux_scaling)"
-        persistent-hint
-      >
-      </v-text-field>
-    </v-row>
+        <v-row>
+          <v-text-field
+            label="Flux scaling"
+            v-model="flux_scaling"
+            hint="Same unit as data, used in -2.5 * log(flux / flux_scaling)"
+            persistent-hint
+          >
+          </v-text-field>
+        </v-row>
 
-    <v-row>
-      <v-select
-        :items="plot_types"
-        v-model="current_plot_type"
-        label="Plot Type"
-        hint="Aperture photometry plot type"
-        persistent-hint
-      ></v-select>
-    </v-row>
+        <v-row>
+          <v-select
+            :items="plot_types"
+            v-model="current_plot_type"
+            label="Plot Type"
+            hint="Aperture photometry plot type"
+            persistent-hint
+          ></v-select>
+        </v-row>
 
-    <v-row justify="end">
-      <v-btn color="primary" text @click="do_aper_phot">Calculate</v-btn>
-    </v-row>
+        <v-row justify="end">
+          <v-btn color="primary" text @click="do_aper_phot">Calculate</v-btn>
+        </v-row>
+      </div>
+    </div>
 
-    <v-row>
+    <v-row v-if="plot_available">
       <!-- NOTE: the internal bqplot widget defaults to 480 pixels, so if choosing something else,
            we will likely need to override that with custom CSS rules in order to avoid the initial
            rendering of the plot from overlapping with content below -->
-      <jupyter-widget v-if="plot_available" :widget="radial_plot" style="width: 100%; height: 480px" />
+      <jupyter-widget :widget="radial_plot" style="width: 100%; height: 480px" />
     </v-row>
 
     <div v-if="result_available">

--- a/jdaviz/configs/imviz/tests/test_parser.py
+++ b/jdaviz/configs/imviz/tests/test_parser.py
@@ -256,10 +256,10 @@ class TestParseImage:
         # Test simple aperture photometry plugin.
         phot_plugin = SimpleAperturePhotometry(app=imviz_helper.app)
         phot_plugin._on_viewer_data_changed()
-        phot_plugin.vue_data_selected('contents[DATA]')
-        phot_plugin.vue_subset_selected('Subset 1')
+        phot_plugin.data_selected = 'contents[DATA]'
+        phot_plugin.subset_selected = 'Subset 1'
         assert_allclose(phot_plugin.background_value, 0)
-        phot_plugin.vue_bg_subset_selected('Subset 2')
+        phot_plugin.bg_subset_selected = 'Subset 2'
         assert_allclose(phot_plugin.background_value, 0.1741226315498352)  # Subset 2 median
         # NOTE: jwst.datamodels.find_fits_keyword("PHOTMJSR")
         phot_plugin.counts_factor = (data.meta['photometry']['conversion_megajanskys'] /
@@ -379,8 +379,8 @@ class TestParseImage:
                                                (1512, 2611))  # Galaxy
         phot_plugin = SimpleAperturePhotometry(app=imviz_helper.app)
         phot_plugin._on_viewer_data_changed()
-        phot_plugin.vue_data_selected('contents[SCI,1]')
-        phot_plugin.vue_subset_selected('Subset 1')
+        phot_plugin.data_selected = 'contents[SCI,1]'
+        phot_plugin.subset_selected = 'Subset 1'
         phot_plugin.background_value = 0.0014  # Manual entry: Median on whole array
         assert_allclose(phot_plugin.pixel_area, 0.0025)  # Not used but still auto-populated
         phot_plugin.vue_do_aper_phot()

--- a/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
+++ b/jdaviz/configs/imviz/tests/test_simple_aper_phot.py
@@ -18,11 +18,11 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         phot_plugin._on_viewer_data_changed()
 
         # Make sure invalid Data/Subset selection does not crash plugin.
-        phot_plugin.vue_data_selected('no_such_data')
+        phot_plugin.data_selected = 'no_such_data'
         assert phot_plugin._selected_data is None
-        phot_plugin.vue_subset_selected('no_such_subset')
+        phot_plugin.subset_selected = 'no_such_subset'
         assert phot_plugin._selected_subset is None
-        phot_plugin.vue_bg_subset_selected('no_such_subset')
+        phot_plugin.bg_subset_selected = 'no_such_subset'
         assert_allclose(phot_plugin.background_value, 0)
         phot_plugin.vue_do_aper_phot()
         assert not phot_plugin.result_available
@@ -32,16 +32,16 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         assert phot_plugin.radial_plot == ''
         assert phot_plugin.current_plot_type == 'Radial Profile'  # Software default
 
-        phot_plugin.vue_data_selected('has_wcs_1[SCI,1]')
-        phot_plugin.vue_subset_selected('no_such_subset')
+        phot_plugin.data_selected = 'has_wcs_1[SCI,1]'
+        phot_plugin.subset_selected = 'no_such_subset'
         assert phot_plugin._selected_subset is None
-        phot_plugin.vue_bg_subset_selected('no_such_subset')
+        phot_plugin.bg_subset_selected = 'no_such_subset'
         assert_allclose(phot_plugin.background_value, 0)
 
         # Perform photometry on both images using same Subset.
-        phot_plugin.vue_subset_selected('Subset 1')
+        phot_plugin.subset_selected = 'Subset 1'
         phot_plugin.vue_do_aper_phot()
-        phot_plugin.vue_data_selected('has_wcs_2[SCI,1]')
+        phot_plugin.data_selected = 'has_wcs_2[SCI,1]'
         phot_plugin.current_plot_type = 'Radial Profile (Raw)'
         phot_plugin.vue_do_aper_phot()
         assert phot_plugin.bg_subset_items == ['Manual', 'Subset 1']
@@ -91,8 +91,8 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         # Make sure it also works on an ellipse subset.
         self.imviz._apply_interactive_region('bqplot:ellipse', (0, 0), (9, 4))
         phot_plugin._on_viewer_data_changed()
-        phot_plugin.vue_data_selected('has_wcs_1[SCI,1]')
-        phot_plugin.vue_subset_selected('Subset 2')
+        phot_plugin.data_selected = 'has_wcs_1[SCI,1]'
+        phot_plugin.subset_selected = 'Subset 2'
         phot_plugin.current_plot_type = 'Radial Profile'
         phot_plugin.vue_do_aper_phot()
         tbl = self.imviz.get_aperture_photometry_results()
@@ -113,9 +113,9 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         # We also subtract off background from itself here.
         self.imviz._apply_interactive_region('bqplot:rectangle', (0, 0), (9, 9))
         phot_plugin._on_viewer_data_changed()
-        phot_plugin.vue_data_selected('has_wcs_1[SCI,1]')
-        phot_plugin.vue_subset_selected('Subset 3')
-        phot_plugin.vue_bg_subset_selected('Subset 3')
+        phot_plugin.data_selected = 'has_wcs_1[SCI,1]'
+        phot_plugin.subset_selected = 'Subset 3'
+        phot_plugin.bg_subset_selected = 'Subset 3'
         assert_allclose(phot_plugin.background_value, 1)
         phot_plugin.vue_do_aper_phot()
         tbl = self.imviz.get_aperture_photometry_results()
@@ -133,14 +133,14 @@ class TestSimpleAperPhot(BaseImviz_WCS_WCS):
         assert tbl[-1]['subset_label'] == 'Subset 3'
 
         # Make sure background auto-updates.
-        phot_plugin.vue_bg_subset_selected('Manual')
-        assert_allclose(phot_plugin.background_value, 0)
-        phot_plugin.vue_bg_subset_selected('Subset 1')
+        phot_plugin.bg_subset_selected = 'Manual'
+        assert_allclose(phot_plugin.background_value, 1)  # Keeps last value
+        phot_plugin.bg_subset_selected = 'Subset 1'
         assert_allclose(phot_plugin.background_value, 1)
         self.imviz.load_data(np.ones((10, 10)) + 1, data_label='twos')
         phot_plugin._on_viewer_data_changed()
-        phot_plugin.vue_data_selected('twos')
-        assert_allclose(phot_plugin.background_value, 2)
+        phot_plugin.data_selected = 'twos'
+        assert_allclose(phot_plugin.background_value, 2)  # Recalculate based on new Data
 
 
 class TestSimpleAperPhot_NoWCS(BaseImviz_WCS_NoWCS):
@@ -150,13 +150,13 @@ class TestSimpleAperPhot_NoWCS(BaseImviz_WCS_NoWCS):
         phot_plugin = SimpleAperturePhotometry(app=self.imviz.app)
         phot_plugin._on_viewer_data_changed()
 
-        phot_plugin.vue_data_selected('has_wcs[SCI,1]')
-        phot_plugin.vue_subset_selected('Subset 1')
+        phot_plugin.data_selected = 'has_wcs[SCI,1]'
+        phot_plugin.subset_selected = 'Subset 1'
         phot_plugin.vue_do_aper_phot()
         tbl = self.imviz.get_aperture_photometry_results()
         assert len(tbl) == 1
 
-        phot_plugin.vue_data_selected('no_wcs[SCI,1]')
+        phot_plugin.data_selected = 'no_wcs[SCI,1]'
         phot_plugin.vue_do_aper_phot()
         tbl = self.imviz.get_aperture_photometry_results()
         assert len(tbl) == 1  # Old table discarded due to incompatible column


### PR DESCRIPTION
* v-model with observe requires more traitlets, but ensures the plugin will remain in sync if changes are made through the API or another instance of the UI.
* some renaming and minor refactoring now that values are stored internally a little differently than before (in traitlets instead of in underscored attributes after triggering the `vue_` methods
* also hide items in the plugin until data is selected to avoid needing to deal with things being changed before.