### PR TITLE
General logic for logger overlay padding/positioning

### DIFF
--- a/jdaviz/app.vue
+++ b/jdaviz/app.vue
@@ -3,7 +3,7 @@
     <v-overlay v-if="state.logger_overlay"
       absolute
       opacity="0.7">
-      <div :style="['imviz', 'cubeviz', 'specviz2d'].indexOf(config) !== -1 ? 'position: absolute; top: 14px; right: 55px' : 'position: absolute; top: 6px; right: 55px'">
+      <div :style="!state.settings.dense_toolbar ? 'position: absolute; top: 14px; right: 55px' : 'position: absolute; top: 6px; right: 55px'">
         <j-tooltip tipid="app-snackbar-history">
           <v-btn icon @click="state.logger_overlay = !state.logger_overlay" :class="{active : state.logger_overlay}">
             <v-icon medium style="padding-top: 2px">mdi-message-reply</v-icon>
@@ -11,10 +11,10 @@
         </j-tooltip>
       </div>
       <div :style="{'position': 'absolute',
-                    'top': ['imviz', 'cubeviz', 'specviz2d'].indexOf(config) !== -1 ? '64px' : '48px',
+                    'top': !state.settings.dense_toolbar ? '64px' : '48px',
                     'left': '0px',
                     'width': '100%',
-                    'height': ['imviz', 'cubeviz', 'specviz2d'].indexOf(config) !== -1 ? 'calc(100% - 64px)' : 'calc(100% - 48px)',
+                    'height': !state.settings.dense_toolbar ? 'calc(100% - 64px)' : 'calc(100% - 48px)',
                     'overflow-y': 'scroll',
                     'border-top': '6px solid #C75109',
                     'padding-left': '15%',


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/jdaviz/blob/main/CODE_OF_CONDUCT.md . -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable viz component(s). -->

This pull request generalized the logic for the logger overlay/padding so that we don't have to constantly update the list of hardcoded configs whenever adding/changing the mouseover coordinates.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
