### PR TITLE
marker for specviz coordinate mouseover

### DIFF
--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -128,6 +128,7 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
                 self.label_mouseover.pixel = ""
                 self.label_mouseover.reset_coords_display()
                 self.label_mouseover.value = ""
+                self.label_mouseover.marks[self._reference_id].visible = False
                 return
 
             fmt = 'x={:0' + str(closest_maxsize) + '.1f}'
@@ -140,12 +141,15 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
             self.label_mouseover.world_dec_deg = closest_flux.unit.to_string()
             self.label_mouseover.icon = closest_label
             self.label_mouseover.value = ""  # Not used
+            self.label_mouseover.marks[self._reference_id].update_xy([closest_wave.value], [closest_flux.value])
+            self.label_mouseover.marks[self._reference_id].visible = True
 
         elif data['event'] == 'mouseleave' or data['event'] == 'mouseenter':
             self.label_mouseover.icon = ""
             self.label_mouseover.pixel = ""
             self.label_mouseover.reset_coords_display()
             self.label_mouseover.value = ""
+            self.label_mouseover.marks[self._reference_id].visible = False
 
     def _expected_subset_layer_default(self, layer_state):
         super()._expected_subset_layer_default(layer_state)

--- a/jdaviz/configs/specviz/plugins/viewers.py
+++ b/jdaviz/configs/specviz/plugins/viewers.py
@@ -131,18 +131,27 @@ class SpecvizProfileView(JdavizViewerMixin, BqplotProfileView):
                 self.label_mouseover.marks[self._reference_id].visible = False
                 return
 
-            fmt = 'x={:0' + str(closest_maxsize) + '.1f}'
-            self.label_mouseover.pixel = fmt.format(closest_i)
-            self.label_mouseover.world_label_prefix = 'Wave'
-            self.label_mouseover.world_ra = f'{closest_wave.value:10.5e}'
-            self.label_mouseover.world_dec = closest_wave.unit.to_string()
-            self.label_mouseover.world_label_prefix_2 = 'Flux'
-            self.label_mouseover.world_ra_deg = f'{closest_flux.value:10.5e}'
-            self.label_mouseover.world_dec_deg = closest_flux.unit.to_string()
-            self.label_mouseover.icon = closest_label
-            self.label_mouseover.value = ""  # Not used
-            self.label_mouseover.marks[self._reference_id].update_xy([closest_wave.value], [closest_flux.value])
-            self.label_mouseover.marks[self._reference_id].visible = True
+            # show the locked marker/coords only if either no tool or the default tool is active
+            locking_active = self.toolbar.active_tool_id in self.toolbar.default_tool_priority + [None]  # noqa
+            if locking_active:
+                fmt = 'x={:0' + str(closest_maxsize) + '.1f}'
+                self.label_mouseover.pixel = fmt.format(closest_i)
+                self.label_mouseover.world_label_prefix = 'Wave'
+                self.label_mouseover.world_ra = f'{closest_wave.value:10.5e}'
+                self.label_mouseover.world_dec = closest_wave.unit.to_string()
+                self.label_mouseover.world_label_prefix_2 = 'Flux'
+                self.label_mouseover.world_ra_deg = f'{closest_flux.value:10.5e}'
+                self.label_mouseover.world_dec_deg = closest_flux.unit.to_string()
+                self.label_mouseover.icon = closest_label
+                self.label_mouseover.value = ""  # Not used
+                self.label_mouseover.marks[self._reference_id].update_xy([closest_wave.value], [closest_flux.value])  # noqa
+                self.label_mouseover.marks[self._reference_id].visible = True
+            else:
+                # show exact plot coordinates (useful for drawing spectral subsets or zoom ranges)
+                fmt = 'x={:+10.5e} y={:+10.5e}'
+                self.label_mouseover.icon = ""
+                self.label_mouseover.pixel = fmt.format(x, y)
+                self.label_mouseover.marks[self._reference_id].visible = False
 
         elif data['event'] == 'mouseleave' or data['event'] == 'mouseenter':
             self.label_mouseover.icon = ""

--- a/jdaviz/core/marks.py
+++ b/jdaviz/core/marks.py
@@ -13,7 +13,7 @@ from jdaviz.core.events import (SliceToolStateMessage, LineIdentifyMessage,
 
 __all__ = ['OffscreenLinesMarks', 'BaseSpectrumVerticalLine', 'SpectralLine',
            'SliceIndicatorMarks', 'ShadowMixin', 'ShadowLine', 'ShadowLabelFixedY',
-           'PluginLine',
+           'PluginLine', 'PluginScatter',
            'LineAnalysisContinuum', 'LineAnalysisContinuumCenter',
            'LineAnalysisContinuumLeft', 'LineAnalysisContinuumRight',
            'LineUncertainties', 'ScatterMask', 'SelectedSpaxel']
@@ -484,17 +484,29 @@ class ShadowLabelFixedY(Label, ShadowMixin):
             self._update_align()
 
 
-class PluginLine(Lines, HubListener):
-    def __init__(self, viewer, x=[], y=[], **kwargs):
-        # color is same blue as import button
-        super().__init__(x=x, y=y, colors=["#007BA1"], scales=viewer.scales, **kwargs)
-
+class PluginMark():
     def update_xy(self, x, y):
         self.x = np.asarray(x)
         self.y = np.asarray(y)
 
+    def append_xy(self, x, y):
+        self.x = np.append(self.x, x)
+        self.y = np.append(self.y, y)
+
     def clear(self):
         self.update_xy([], [])
+
+
+class PluginLine(Lines, PluginMark, HubListener):
+    def __init__(self, viewer, x=[], y=[], **kwargs):
+        # color is same blue as import button
+        super().__init__(x=x, y=y, colors=["#007BA1"], scales=viewer.scales, **kwargs)
+
+
+class PluginScatter(Scatter, PluginMark, HubListener):
+    def __init__(self, viewer, x=[], y=[], **kwargs):
+        # color is same blue as import button
+        super().__init__(x=x, y=y, colors=["#007BA1"], scales=viewer.scales, **kwargs)
 
 
 class LineAnalysisContinuum(PluginLine):


### PR DESCRIPTION
This is the most basic implementation of a marker in the spectrum viewer that indicates the position of the coordinates display.  Before merging, we may want to consider some way to disable this (or disable when other tools - ie zoom or subset creation - are active).

At the least, this might help to test and debug behavior of https://github.com/spacetelescope/jdaviz/pull/1894.  




https://user-images.githubusercontent.com/877591/210076987-1ecf89c7-e073-4e7b-9644-690c51780294.mov



https://user-images.githubusercontent.com/877591/210077091-872161a1-f6c9-4e56-afcb-526d8add5299.mov



**TODO**:
- [ ] option to disable or automatically disable when other tools are active in the viewer?

