### PR TITLE
keep vertical position of colorbar fixed

### DIFF
--- a/jdaviz/configs/default/plugins/plot_options/plot_options.py
+++ b/jdaviz/configs/default/plugins/plot_options/plot_options.py
@@ -408,8 +408,8 @@ class PlotOptions(PluginTemplateMixin):
         self.stretch_histogram._add_data('histogram', x=[0, 1])
 
         self.stretch_histogram.add_line('vmin', x=[0, 0], y=[0, 1], ynorm=True, color='#c75d2c')
-        self.stretch_histogram.add_line('vmax', x=[0, 0], y=[0, 1], ynorm=True, color='#c75d2c')
-        self.stretch_histogram.add_scatter('colorbar', x=[0, 0], y=[0, 1], marker='square', stroke_width=33)  # noqa: E501
+        self.stretch_histogram.add_line('vmax', x=[0, 0], y=[0, 1], ynorm='vmin', color='#c75d2c')
+        self.stretch_histogram.add_scatter('colorbar', x=[], y=[], ynorm='vmin', marker='square', stroke_width=33)  # noqa: E501
         with self.stretch_histogram.figure.hold_sync():
             self.stretch_histogram.figure.axes[0].label = 'pixel value'
             self.stretch_histogram.figure.axes[0].num_ticks = 3
@@ -695,7 +695,7 @@ class PlotOptions(PluginTemplateMixin):
             stretch = stretches.members[self.stretch_function_value]
 
             x = self.stretch_histogram.figure.marks[0].x
-            y = np.full(x.shape, self.stretch_histogram.figure.axes[1].scale.max)
+            y = np.ones_like(x)
 
             # Copied from the __call__ internals of glue/viewers/image/composite_array.py
             data = interval(x)

--- a/jdaviz/core/template_mixin.py
+++ b/jdaviz/core/template_mixin.py
@@ -3418,10 +3418,28 @@ class Plot(PluginSubcomponent):
         self.clear_marks(*self.marks.keys())
 
     def _add_mark(self, cls, label, xnorm=False, ynorm=False, **kwargs):
+        """
+        Parameters
+        ----------
+        xnorm : bool or str
+            If True, axes will be normalized.  If a string of an existing mark, this mark will
+            share that same x-axis scale.
+        ynorm : bool or str
+            If True, axes will be normalized.  If a string of an existing mark, this mark will
+            share that same y-axis scale.
+        """
         if label in self._marks:
             raise ValueError(f"mark with label '{label}' already exists")
-        mark = cls(scales={'x': bqplot.LinearScale() if xnorm else self.figure.axes[0].scale,
-                           'y': bqplot.LinearScale() if ynorm else self.figure.axes[1].scale},
+        scales = {}
+        for dim, norm in zip(('x', 'y'), (xnorm, ynorm)):
+            if isinstance(norm, str) and norm in self._marks.keys():
+                # point to an existing marks scales
+                scales[dim] = self._marks[norm].scales[dim]
+            elif norm:
+                scales[dim] = bqplot.LinearScale()
+            else:
+                scales[dim] = self.figure.axes[0].scale
+        mark = cls(scales=scales,
                    **kwargs)
         self.figure.marks = self.figure.marks + [mark]
         self._marks[label] = mark


### PR DESCRIPTION
This PR supports referencing the axis scale of an existing mark and using that to tie the colorbars vertical position to the top of the vmin/vmax vertical lines.